### PR TITLE
Fixed angular2-csv to version below 0.2.9, because exported module is…

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "@angular/router": "^4.4.3",
     "@ngx-translate/core": "^8.0.0",
     "@ngx-translate/http-loader": "^1.0.2",
-    "angular2-csv": "^0.2.5",
+    "angular2-csv": "^0.2.5 <0.2.9",
     "core-js": "^2.4.1",
     "d3": "^4.10.2",
     "font-awesome": "^4.7.0",


### PR DESCRIPTION
… called differtently from that version.